### PR TITLE
coveralls.io integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ jdk:
     - openjdk7
 before_install:
     - mvn install:install-file -Dfile=lib/javarosa.jar -DgroupId=org.javarosa -DartifactId=javarosa-libraries -Dversion=latest -Dpackaging=jar -DgeneratePom=true
+after_success:
+    - mvn clean cobertura:cobertura coveralls:cobertura
 services:
     - redis-server

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <format>xml</format>
+                    <maxmem>256m</maxmem>
+                    <!-- aggregated reports for multi-module projects -->
+                    <aggregate>true</aggregate>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>2.2.0</version>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
added two build dependencies (`cobertura` and `coveralls-maven-plugin`) for generating coverage reports for the project
